### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MBBarMenu
 MBBarMenu simplifies the arrangement of multiple UIBarButtonItems in an iOS UINavigationBar. Up to a given count the items will be shown normally. If the number of items exceeds this threshold, all remaining items will be shown in a UIAlertController.
 
-[![Build Status](https://img.shields.io/travis/mathebox/MBBarMenu.svg?style=flat)](https://travis-ci.org/mathebox/MBBarMenu) [![Cocoapods](https://img.shields.io/cocoapods/v/MBBarMenu.svg?style=flat)](http://cocoapods.org/?q=mbbarmenu) ![Platform](https://img.shields.io/cocoapods/p/MBBarMenu.svg?style=flat) ![License](https://img.shields.io/cocoapods/l/MBBarMenu.svg?style=flat)
+[![Build Status](https://img.shields.io/travis/mathebox/MBBarMenu.svg?style=flat)](https://travis-ci.org/mathebox/MBBarMenu) [![CocoaPods](https://img.shields.io/cocoapods/v/MBBarMenu.svg?style=flat)](http://cocoapods.org/?q=mbbarmenu) ![Platform](https://img.shields.io/cocoapods/p/MBBarMenu.svg?style=flat) ![License](https://img.shields.io/cocoapods/l/MBBarMenu.svg?style=flat)
 
 ### on iPhone
 ![MBBarMenu Example Phone](https://raw.githubusercontent.com/mathebox/MBBarMenu/master/assets/example_phone.png)


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
